### PR TITLE
Improve date validation.

### DIFF
--- a/src/Model/Schema/Attribute.php
+++ b/src/Model/Schema/Attribute.php
@@ -213,7 +213,8 @@ class Attribute implements SerializableInterface
             case ScimConstants::ATTRIBUTE_TYPE_BOOLEAN: return is_bool($value);
             case ScimConstants::ATTRIBUTE_TYPE_DECIMAL: return is_float($value) || is_int($value);
             case ScimConstants::ATTRIBUTE_TYPE_INTEGER: return is_int($value);
-            case ScimConstants::ATTRIBUTE_TYPE_DATETIME: return $value instanceof \DateTime;  // improve this
+            case ScimConstants::ATTRIBUTE_TYPE_DATETIME:
+                return $value instanceof \DateTime || false !== \DateTime::createFromFormat(\DateTime::ATOM, $value);
             case ScimConstants::ATTRIBUTE_TYPE_BINARY: return true;
             case ScimConstants::ATTRIBUTE_TYPE_REFERENCE: return is_string($value); // improve this
             case ScimConstants::ATTRIBUTE_TYPE_COMPLEX: return is_array($value) || is_object($value);

--- a/tests/Validator/SchemaValidatorTest.php
+++ b/tests/Validator/SchemaValidatorTest.php
@@ -202,6 +202,36 @@ class SchemaValidatorTest extends \PHPUnit_Framework_TestCase
         ], $result->getErrorsAsStrings());
     }
 
+    public function test_error_on_invalid_datetime_type()
+    {
+        $schema = new Schema(ScimConstantsV2::SCHEMA_USER);
+        $schema->addAttribute(
+            AttributeBuilder::create('birthDate', ScimConstants::ATTRIBUTE_TYPE_DATETIME)->getAttribute()
+        );
+
+        $object = ['birthDate' => '17/5-1814'];
+
+        $result = $this->validator->validate($object, $schema);
+
+        $this->assertEquals([
+            '[birthDate] Attribute has invalid value for type "dateTime" [urn:ietf:params:scim:schemas:core:2.0:User]',
+        ], $result->getErrorsAsStrings());
+    }
+
+    public function test_no_error_on_valid_datetime_type()
+    {
+        $schema = new Schema(ScimConstantsV2::SCHEMA_USER);
+        $schema->addAttribute(
+            AttributeBuilder::create('birthDate', ScimConstants::ATTRIBUTE_TYPE_DATETIME)->getAttribute()
+        );
+
+        $object = ['birthDate' => '2019-01-31T17:19:37+01:00'];
+
+        $result = $this->validator->validate($object, $schema);
+
+        $this->assertEmpty($result->getErrors());
+    }
+
     public function test_error_on_invalid_attribute_in_schema_extension()
     {
         $schema = new Schema(ScimConstantsV2::SCHEMA_USER);


### PR DESCRIPTION
SCIM dates are represented as a string, but the validator would only accept DateTime php objects.

This patch extends the the type validation for DateTime attributes to allow for valid date strings.