### PR TITLE
Resource is added twice to ListResponse.

### DIFF
--- a/src/Model/ListResponse.php
+++ b/src/Model/ListResponse.php
@@ -86,10 +86,11 @@ abstract class ListResponse extends SchemaBase implements SerializableInterface
         foreach ($this->resources as $resource) {
             if ($resource instanceof SerializableInterface) {
                 $result['Resources'][] = $resource->serializeObject();
-            } elseif (!is_array($resource)) {
-                throw new \InvalidArgumentException('Resource must implement SerializableInterface or already be serialized to array');
+            } elseif (is_array($resource)) {
+                $result['Resources'][] = $resource;
+            } else {
+              throw new \InvalidArgumentException('Resource must implement SerializableInterface or already be serialized to array');
             }
-            $result['Resources'][] = $resource;
         }
 
         return $result;


### PR DESCRIPTION
Hi, 

Some years ago, I forked this project in order to fix what appears to be a bug : the $resource here is added twice to the ListResponse.

I don't know if there are datastructures other than SerializableInterface and array to handle, but I still provide this PR, never too late!

What do you think?

Regards,